### PR TITLE
bugfix: Fix LAN IP selection and periodic input stalls on macOS/iOS

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/IPEnumeration.cpp
+++ b/Core/GameEngine/Source/GameNetwork/IPEnumeration.cpp
@@ -112,10 +112,25 @@ EnumeratedIP * IPEnumeration::getAddresses()
 				continue;
 			}
 
+			// GeneralsX @bugfix 07/07/2026 Skip point-to-point interfaces: cellular (pdp_ip* on iOS) and
+			// VPN tunnels (utun*) are not reachable by LAN peers, and their addresses sort numerically
+			// below the Wi-Fi/Ethernet address, so the LAN lobby would pick them as the default IP.
+			if ((ifa->ifa_flags & IFF_POINTOPOINT) != 0)
+			{
+				continue;
+			}
+
 			const sockaddr_in *addr = reinterpret_cast<const sockaddr_in *>(ifa->ifa_addr);
 			// GeneralsX @bugfix BenderAI 31/03/2026 Use ntohl to convert from network byte order before extracting octets;
 			// reading s_addr byte-by-byte on little-endian platforms reverses the IPv4 octets.
 			const UnsignedInt hostAddr = ntohl(addr->sin_addr.s_addr);
+
+			// GeneralsX @bugfix 07/07/2026 Skip 169.254.0.0/16 link-local addresses (awdl0/llw0 on Apple
+			// platforms, or any interface that failed DHCP); they cannot host a LAN game.
+			if ((hostAddr & 0xFFFF0000u) == 0xA9FE0000u)
+			{
+				continue;
+			}
 			addNewIP(
 				(UnsignedByte)((hostAddr >> 24) & 0xFF),
 				(UnsignedByte)((hostAddr >> 16) & 0xFF),

--- a/Core/Libraries/Source/WWVegas/WWLib/systimer.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/systimer.h
@@ -46,13 +46,16 @@
 #define TIMEGETTIME SystemTime.Get
 #define MS_TIMER_SECOND 1000
 #else
-#include <sys/time.h>
+#include <time.h>
 
+// GeneralsX @bugfix 07/07/2026 Use the monotonic clock, not gettimeofday: wall time steps
+// backward on NTP/carrier sync (frequent on iOS), and every elapsed-time gate in the engine
+// (shell updates, animations, network resends) then stalls until the clock catches back up.
 inline unsigned long systimerGetMS()
 {
-	struct timeval tv;
-	gettimeofday(&tv, nullptr);
-	return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (unsigned long)((unsigned long long)ts.tv_sec * 1000ull + (unsigned long long)ts.tv_nsec / 1000000ull);
 }
 
 #define TIMEGETTIME systimerGetMS

--- a/Generals/Code/CompatLib/Include/windows_compat.h
+++ b/Generals/Code/CompatLib/Include/windows_compat.h
@@ -183,11 +183,14 @@ inline BOOL GetVersionEx(OSVERSIONINFO* lpVersionInfo) {
 
 // TheSuperHackers @build 10/02/2026 Bender
 // Timing functions: timeBeginPeriod(), timeEndPeriod() for Linux
+// GeneralsX @bugfix 07/07/2026 Use the monotonic clock, not gettimeofday: wall time steps
+// backward on NTP/carrier sync (frequent on iOS), and every elapsed-time gate in the engine
+// (shell updates, animations, network resends) then stalls until the clock catches back up.
 static inline DWORD timeGetTime(void)
 {
-    struct timeval tv;
-    gettimeofday(&tv, nullptr);
-    return (DWORD)((tv.tv_sec * 1000) + (tv.tv_usec / 1000));
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (DWORD)((unsigned long long)ts.tv_sec * 1000ull + (unsigned long long)ts.tv_nsec / 1000000ull);
 }
 
 static inline DWORD timeBeginPeriod(DWORD period)

--- a/GeneralsMD/Code/CompatLib/Include/windows_compat.h
+++ b/GeneralsMD/Code/CompatLib/Include/windows_compat.h
@@ -183,11 +183,14 @@ inline BOOL GetVersionEx(OSVERSIONINFO* lpVersionInfo) {
 
 // TheSuperHackers @build 10/02/2026 Bender
 // Timing functions: timeBeginPeriod(), timeEndPeriod() for Linux
+// GeneralsX @bugfix 07/07/2026 Use the monotonic clock, not gettimeofday: wall time steps
+// backward on NTP/carrier sync (frequent on iOS), and every elapsed-time gate in the engine
+// (shell updates, animations, network resends) then stalls until the clock catches back up.
 static inline DWORD timeGetTime(void)
 {
-    struct timeval tv;
-    gettimeofday(&tv, nullptr);
-    return (DWORD)((tv.tv_sec * 1000) + (tv.tv_usec / 1000));
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (DWORD)((unsigned long long)ts.tv_sec * 1000ull + (unsigned long long)ts.tv_nsec / 1000000ull);
 }
 
 static inline DWORD timeBeginPeriod(DWORD period)

--- a/scripts/build/ios/package-ios-zh.sh
+++ b/scripts/build/ios/package-ios-zh.sh
@@ -190,11 +190,9 @@ echo "==> App ready: ${APP}"
 
 if [[ "${DO_INSTALL}" == "1" ]]; then
     echo "==> Installing to connected device"
-    DEVICE_ID=$(xcrun devicectl list devices 2>/dev/null | awk '/connected/{print $(NF-2); exit}')
-    if [[ -z "${DEVICE_ID}" ]]; then
-        # fall back: parse the identifier column (3rd-from-last varies with model names)
-        DEVICE_ID=$(xcrun devicectl list devices 2>/dev/null | grep -i connected | grep -oE '[0-9A-F-]{36}' | head -1)
-    fi
+    # Extract the identifier by shape (UUID), not by column position — the column
+    # index shifts with multi-word device/model names (e.g. "iPhone 15 Pro Max").
+    DEVICE_ID=$(xcrun devicectl list devices 2>/dev/null | grep -i connected | grep -oE '[0-9A-F]{8}(-[0-9A-F]{4}){3}-[0-9A-F]{12}' | head -1)
     if [[ -z "${DEVICE_ID}" ]]; then
         echo "ERROR: no connected device found (xcrun devicectl list devices)"
         exit 1


### PR DESCRIPTION
**Merge with Rebase** (three standalone fixes, each compiles independently)

## What this fixes

### 1. LAN multiplayer binds to an unreachable IP address (network)

On POSIX platforms `IPEnumeration::getAddresses()` accepts every non-loopback
IPv4 interface. On iOS this includes cellular (`pdp_ip*`) and VPN tunnel
(`utun*`) interfaces, and on macOS link-local `169.254.0.0/16` addresses from
auxiliary interfaces (e.g. the iPhone-USB bridge). Because the list is sorted
ascending and the LAN lobby takes the first entry, these addresses win over the
real Wi-Fi/Ethernet address and LAN games bind to an interface no LAN peer can
reach. The fix skips `IFF_POINTOPOINT` interfaces and link-local addresses.
Interface names are deliberately not whitelisted so hotspot play (`bridge100`)
keeps working.

### 2. Recurring 10-15 second UI/input stalls (system)

`timeGetTime()` is implemented with `gettimeofday()` on POSIX (both CompatLib
copies and `systimer.h`). Wall time steps backward on NTP/carrier time sync —
frequent on iOS. Every elapsed-time gate in the engine (shell screen updates,
window animations, transitions, network resend timers) then stalls until the
clock catches back up, which presents as the game ignoring touches for the
size of the step while rendering continues. Reproduced on device: the engine
log shows button taps registering (`Shell::push`) while the pending screen
transition sits unprocessed for many seconds. The fix switches both shims to
`CLOCK_MONOTONIC`.

### 3. iOS packaging script fails on multi-word device names (tooling)

`devicectl list devices` output is parsed by column position, which shifts
with names like "iPhone 15 Pro Max". Parse the identifier by UUID shape
instead.

## Testing

- The LAN IP fix is verified on device (iPhone 15 Pro Max) and on an Apple
  Silicon Mac: the LAN lobby now selects the Wi-Fi address (previously a
  cellular `10.x` address on iOS and a link-local `169.254.x` address on macOS).
- The monotonic clock fix is build-verified; on-device soak testing in progress.
- Builds clean for `macos-vulkan` (Zero Hour + Generals) and `ios-vulkan`
  (Zero Hour) presets.

## AI disclosure

The changes in this PR were generated with an LLM (Claude Code), reviewed
line-by-line, and tested by the author as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)