### PR TITLE
fix(ios): extract device UDID by id shape, not column position, in package-ios-zh.sh

### DIFF
--- a/scripts/build/ios/package-ios-zh.sh
+++ b/scripts/build/ios/package-ios-zh.sh
@@ -190,11 +190,18 @@ echo "==> App ready: ${APP}"
 
 if [[ "${DO_INSTALL}" == "1" ]]; then
     echo "==> Installing to connected device"
-    DEVICE_ID=$(xcrun devicectl list devices 2>/dev/null | awk '/connected/{print $(NF-2); exit}')
-    if [[ -z "${DEVICE_ID}" ]]; then
-        # fall back: parse the identifier column (3rd-from-last varies with model names)
-        DEVICE_ID=$(xcrun devicectl list devices 2>/dev/null | grep -i connected | grep -oE '[0-9A-F-]{36}' | head -1)
-    fi
+    # Match only valid device-identifier shapes on the "connected" row, so a
+    # multi-word model name (e.g. "iPad Pro 13-inch (M4)") can never be mistaken
+    # for the identifier the way column counting was. Case-insensitive because
+    # devicectl prints lowercase ids. Handles:
+    #   - 40-char legacy physical UDID (hex)
+    #   - 25-char modern physical UDID: 00008020-001234567890ABCD (8-16)
+    #   - 36-char CoreDevice/simulator UUID: 8-4-4-4-12
+    # -w so the state word "connected" does not also match "disconnected".
+    DEVICE_ID=$(xcrun devicectl list devices 2>/dev/null \
+        | grep -iw 'connected' \
+        | grep -ioE '([0-9a-f]{40}|[0-9a-f]{8}-[0-9a-f]{16}|[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})' \
+        | head -1)
     if [[ -z "${DEVICE_ID}" ]]; then
         echo "ERROR: no connected device found (xcrun devicectl list devices)"
         exit 1


### PR DESCRIPTION
## Summary

`scripts/build/ios/package-ios-zh.sh --install` now finds the target device by matching the identifier's shape instead of counting columns, so deploying to a device whose model name contains spaces works.

## Why this matters

The install path read the device id with `awk '/connected/{print $(NF-2); exit}'` — the third field from the end of the row. `xcrun devicectl list devices` puts the model name last, so any multi-word model (`iPad Pro 13-inch (M4)`, `iPhone 15 Pro Max`) shifts the columns and the script captures a fragment like `13-inch`. Because that's non-empty it never falls through, and install fails with `devicectl device install app --device 13-inch`. The fallback was broken two more ways: `grep -oE '[0-9A-F-]{36}'` is uppercase-only (devicectl prints lowercase) and fixed at 36 chars, so it missed both 25-char modern physical UDIDs (`00008020-001234567890ABCD`) and 40-char legacy ones. The issue reporter diagnosed this and proposed a shape-matching regex.

## Changes

Replaced the awk field-count and the broken fallback with one case-insensitive extraction on the connected row:

```sh
DEVICE_ID=$(xcrun devicectl list devices 2>/dev/null \
    | grep -iw 'connected' \
    | grep -ioE '([0-9a-f]{40}|[0-9a-f]{8}-[0-9a-f]{16}|[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})' \
    | head -1)
```

It matches only valid id shapes (40-char hex, 8-16 modern, 8-4-4-4-12 UUID), so a model-name fragment can't be selected. One refinement over the proposed snippet: the state filter uses `grep -iw` so `connected` doesn't also match `disconnected` — otherwise a disconnected device's id would be picked and install would target an offline device. The empty-result error path and the `devicectl device install` call are unchanged.

## Testing

`devicectl` needs real hardware, so I verified the extraction against representative fixture rows plus `bash -n`:

- `bash -n scripts/build/ios/package-ios-zh.sh`: passes
- Multi-word model + modern UDID (the reported case) → the UDID (old awk gave `13-inch`)
- Lowercase 36-char CoreDevice UUID → the UUID (old fallback missed lowercase)
- 40-char legacy hex UDID → the full id
- Disconnected-only list → empty, so the existing "no connected device found" error fires
- Mixed connected + disconnected rows → the connected device's id

Fixes #4
