### PR TITLE
macos: move SagePatch window-snap off Ctrl+1..5 to stop shadowing control groups

### DIFF
--- a/Patches/SagePatch/src/common/Init.cpp
+++ b/Patches/SagePatch/src/common/Init.cpp
@@ -28,7 +28,7 @@ void init() {
     SAGEPATCH_LOG("  F11             screenshot (PNG to ~/Pictures/GeneralsX)");
     SAGEPATCH_LOG("  Scroll Lock     toggle cursor lock");
     SAGEPATCH_LOG("  Ctrl+PageUp/Dn  brightness +/-");
-    SAGEPATCH_LOG("  Ctrl+1..5       window position (center / TL / TR / BL / BR)");
+    SAGEPATCH_LOG("  Alt+1..5        window position (center / TL / TR / BL / BR)");
 }
 
 void shutdown() {}

--- a/Patches/SagePatch/src/common/KeyHandler.cpp
+++ b/Patches/SagePatch/src/common/KeyHandler.cpp
@@ -11,6 +11,11 @@ bool handleKeyDown(const SDL_KeyboardEvent& ev) {
     if (!window) return false;
 
     const bool ctrl = (ev.mod & SDL_KMOD_CTRL) != 0;
+    // @fix window-snap used Ctrl+1..5, which shadows Generals' native
+    // Ctrl+<number> control-group hotkeys (SDL_PollEvent interposer here
+    // consumes the event before the game ever sees it). Moved to Alt so both
+    // features work: Alt+1..5 for window position, Ctrl+1..9/0 for control groups.
+    const bool alt = (ev.mod & SDL_KMOD_ALT) != 0;
 
     switch (ev.key) {
         case SDLK_F11:
@@ -29,19 +34,19 @@ bool handleKeyDown(const SDL_KeyboardEvent& ev) {
             break;
 
         case SDLK_1:
-            if (ctrl) { moveWindow(window, WindowPosition::Center); return true; }
+            if (alt) { moveWindow(window, WindowPosition::Center); return true; }
             break;
         case SDLK_2:
-            if (ctrl) { moveWindow(window, WindowPosition::TopLeft); return true; }
+            if (alt) { moveWindow(window, WindowPosition::TopLeft); return true; }
             break;
         case SDLK_3:
-            if (ctrl) { moveWindow(window, WindowPosition::TopRight); return true; }
+            if (alt) { moveWindow(window, WindowPosition::TopRight); return true; }
             break;
         case SDLK_4:
-            if (ctrl) { moveWindow(window, WindowPosition::BottomLeft); return true; }
+            if (alt) { moveWindow(window, WindowPosition::BottomLeft); return true; }
             break;
         case SDLK_5:
-            if (ctrl) { moveWindow(window, WindowPosition::BottomRight); return true; }
+            if (alt) { moveWindow(window, WindowPosition::BottomRight); return true; }
             break;
 
         default:

--- a/Patches/SagePatch/src/common/WindowPosition.cpp
+++ b/Patches/SagePatch/src/common/WindowPosition.cpp
@@ -1,4 +1,4 @@
-// Window position presets — Ctrl+1..5 to snap the window to common positions
+// Window position presets — Alt+1..5 to snap the window to common positions
 // on the active display. SDL3 does the work; works on every platform.
 
 #include "SagePatch/Features.h"


### PR DESCRIPTION
## Summary
- SagePatch's `SDL_PollEvent` interposer (`Patches/SagePatch/src/macos/interposers_macos.cpp`) consumes every keydown event it recognizes before it reaches the game engine.
- `KeyHandler.cpp` bound its window-position presets to `Ctrl+1..5`, which is exactly the same chord Generals' native input layer uses for control-group create/select (`CREATE_TEAM0..9` / `SELECT_TEAM0..9` in `MetaEvent.cpp`).
- Net effect: on this macOS/SDL3 port, `Ctrl+1` through `Ctrl+5` never reached the game — control groups were silently unusable for half the numpad row, since SagePatch swallowed the event and returned `true` (handled).
- Moved the window-snap hotkeys to `Alt+1..5` (`SDL_KMOD_ALT`) so both features coexist: `Alt+1..5` for window position, `Ctrl+<number>` free for the game's own control-group bindings.
- Updated the startup hotkey log line and the file header comment to match.

## Why
Found this live while playtesting a fresh macOS build — RMB drag-scrolling worked but edge-scroll and control groups didn't feel right. Edge-scroll turned out to be a local `Options.ini` setting (`ScreenEdgeScrollEnabledInWindowedApp`, not part of this PR); control groups turned out to be this repo's own SagePatch QoL layer stepping on the engine's default keybinds.

## Test plan
- [x] Rebuilt only the `sage_patch` CMake target (`cmake --build build/macos-vulkan --target sage_patch`) and redeployed `libsage_patch.dylib`.
- [x] Relaunched Zero Hour with the patch loaded via `DYLD_INSERT_LIBRARIES`; confirmed `Alt+1..5` still snaps the window to each preset position.
- [x] Confirmed `Ctrl+<number>` now reaches the game and creates/selects control groups as expected.