### PR TITLE
audio: fix OpenAL buffer leak (~26 MB/min) — alDeleteBuffers never succeeded

### DIFF
--- a/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioCache.cpp
+++ b/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioCache.cpp
@@ -132,8 +132,6 @@ ALuint OpenALAudioFileCache::getBufferForFile(const OpenFileInfo &fileInfo)
 		return 0;
 	}
 
-	UnsignedInt fileSize = file->size();
-
 	OpenAudioFile openedAudioFile;
 	alGenBuffers(1, &openedAudioFile.m_buffer);
 	openedAudioFile.m_eventInfo = eventToOpenFrom ? eventToOpenFrom->getAudioEventInfo() : NULL;
@@ -160,7 +158,12 @@ ALuint OpenALAudioFileCache::getBufferForFile(const OpenFileInfo &fileInfo)
 
 	openedAudioFile.m_ffmpegFile->close();
 
-	openedAudioFile.m_fileSize = fileSize;
+	// GeneralsX @bugfix Marco 24/08/2026 Account for the DECODED PCM size, not the
+	// compressed file size. decodeFFmpeg() accumulates m_fileSize per frame; assigning
+	// file->size() here overwrote it with a far smaller value, so the cache
+	// under-reported its real footprint and evicted much later than intended.
+	// (This is not what caused the buffer leak - see releaseOpenAudioFile - but
+	// the accounting was wrong regardless.)
 	m_currentlyUsedSize += openedAudioFile.m_fileSize;
 	if (m_currentlyUsedSize > m_maxSize) {
 		DEBUG_LOG(("Audio Cache is full, trying to free some space\n"));

--- a/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioCache.cpp
+++ b/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioCache.cpp
@@ -118,6 +118,17 @@ ALuint OpenALAudioFileCache::getBufferForFile(const OpenFileInfo &fileInfo)
 		}
 	}
 
+	// GeneralsX @bugfix Marco 24/08/2026 Bail out early when there is no filename
+	// to load. Some stock audio events ship with an empty "Sounds =" list -
+	// TurretMoveLoop and RadarEvent among them. TurretMoveLoop is declared
+	// "loop all random", so startNextLoop() regenerates the (empty) filename and
+	// lands here again every frame, each time walking all the way down to
+	// TheFileSystem->openFile("") before failing. Nothing was leaked, but the
+	// lookup and the BIG-archive access were pure waste, several times a second.
+	if (strToFind.isEmpty()) {
+		return 0;
+	}
+
 	auto it = m_openFiles.find(strToFind);
 
 	if (it != m_openFiles.end()) {

--- a/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioCache.cpp
+++ b/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioCache.cpp
@@ -224,7 +224,13 @@ void OpenALAudioFileCache::setMaxSize(UnsignedInt size)
 //-------------------------------------------------------------------------------------------------
 void OpenALAudioFileCache::releaseOpenAudioFile(OpenAudioFile* fileToRelease)
 {
-	if (fileToRelease->m_openCount > 0) {
+	// GeneralsX @bugfix Marco 24/08/2026 Always detach the buffer from any source
+	// still referencing it - not just when m_openCount > 0. The cache reference is
+	// dropped (closeBuffer) before the source gets a new buffer assigned, so a
+	// buffer with m_openCount == 0 can still be bound to a live OpenAL source.
+	// alDeleteBuffers then fails with AL_INVALID_OPERATION and the buffer leaks;
+	// measured: 1158 of 1158 deletions failed, ~26 MB/min lost.
+	if (fileToRelease->m_buffer) {
 		// This thing needs to be terminated IMMEDIATELY.
 		TheAudio->closeAnySamplesUsingFile((const void*)(uintptr_t)fileToRelease->m_buffer);
 	}


### PR DESCRIPTION
## The problem

Long sessions kept growing until the machine started swapping. Measured on
macOS/arm64: **+25.7 MB/min, perfectly linear over 97 samples**, no plateau.
After roughly two hours the process sat at ~5 GB and the system was thrashing
(2.2% CPU, 5.1M pageouts on an 8 GB machine).

97% of the heap growth came from a single allocator:

```
GameEngine::update()
└─ OpenALAudioManager::update()
   └─ processPlayingList()
      └─ notifyOfAudioCompletion()
         └─ startNextLoop()
            └─ playSample3D()
               └─ OpenALAudioFileCache::getBufferForFile()
                  └─ decodeFFmpeg()
                     └─ alBufferData → alBufferStorageDirectSOFT
```

## Root cause

`releaseOpenAudioFile()` only detached the buffer from playing sources when
`m_openCount > 0`. But the cache reference is dropped (`closeBuffer`) *before*
the still-playing source is handed a new buffer — so a buffer with
`m_openCount == 0` can very much still be bound to a live OpenAL source.
`alDeleteBuffers()` then fails with `AL_INVALID_OPERATION`, and **nobody checks
the return value**.

Instrumenting `alGetError()` right after the call made it unambiguous:

```
before:  0 of 1158 alDeleteBuffers calls succeeded
after:   880 of 889 succeeded
```

Not a single audio buffer was ever freed for the lifetime of the process.

## Result

| | before | after |
|---|---|---|
| successful buffer deletions | 0 / 1158 | 880 / 889 |
| memory growth | 25.7 MB/min | **1.45 MB/min** |
| per hour | ~1.6 GB | ~87 MB |

Measured over 11 minutes, then re-confirmed on the committed tree. The
remainder is ordinary cache warm-up — the footprint now also *drops* again as
the cache evicts, which it never did before.

## The commits

1. **`account for decoded PCM size`** — `decodeFFmpeg()` accumulates the decoded
   size into `m_fileSize`, but `getBufferForFile()` immediately overwrote it
   with `file->size()` (the compressed size), so the cache under-reported its
   own footprint. Explicitly **not** the cause of the leak — verified by
   applying it alone, which changed nothing (+1392 buffers/3 min vs +1451).
   Wrong accounting regardless.
2. **`fix OpenAL buffer leak`** — the actual fix described above.
3. **`skip cache lookup for audio events without a filename`** — `TurretMoveLoop`
   and `RadarEvent` ship with an empty `Sounds =` in the retail `INIZH.big`.
   TurretMoveLoop is `loop all random`, so it regenerated the empty filename and
   walked down to `TheFileSystem->openFile("")` every single frame. Nothing
   leaked, but up to 12813 futile calls in five minutes against 2948 real ones.

Commit 1 is the weakest of the three and can be dropped without affecting the
fix, if you prefer to keep this tight.

## Reproducing

No gameplay required — the **main menu** is enough, since the menu music loops
and every loop re-decodes a sample. Watch `GeneralsXZH` in Activity Monitor, or:

```sh
footprint -p <pid>      # not `ps -o rss` — heap/leaks suspend the process and
                        # RSS then drops by hundreds of MB without any real free
```

Note that `leaks` reports nothing useful here (only ~18 KB of system XPC
cycles): the buffers stay reachable, so this is a cache that never drains
rather than a classic leak.

## Scope

`Core/GameEngineDevice/Source/OpenALAudioDevice/` is shared, so this affects
Linux as well as macOS. Windows uses Miles Audio and is unaffected.
Verified on macOS 15 / arm64 (MoltenVK + DXVK + SDL3); I have not been able to
test the Linux build.
